### PR TITLE
Reorder customer option merge to prevent overwriting passed attributes

### DIFF
--- a/lib/fake_braintree/customer.rb
+++ b/lib/fake_braintree/customer.rb
@@ -3,8 +3,10 @@ module FakeBraintree
     include Helpers
 
     def initialize(customer_hash, options)
-      @customer_hash = customer_hash.merge("merchant_id" => options[:merchant_id],
-                                           "id" => options[:id])
+      @customer_hash = {
+        "id" => options[:id],
+        "merchant_id" => options[:merchant_id]
+      }.merge(customer_hash)
     end
 
     def create

--- a/spec/fake_braintree/customer_spec.rb
+++ b/spec/fake_braintree/customer_spec.rb
@@ -14,6 +14,12 @@ describe "Braintree::Customer.create" do
     result.should be_success
   end
 
+  it "does not overwrite a passed customer id" do
+    result = Braintree::Customer.create({ "id" => '123' })
+
+    result.customer.id.should eq('123')
+  end
+
   it "creates a customer using an expiration month and year" do
     result = Braintree::Customer.create(:credit_card => { :number => TEST_CC_NUMBER,
                                                           :expiration_month => '04',


### PR DESCRIPTION
Running into this issue when trying to sync the created customer.id with a local record's id. Without this the id will always be overwritten as nil.
