### PR TITLE
Allow credit card verification on customer#update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 * The server code (it intercepts calls to Braintree) now lives in FakeBraintree::Server
 * Braintree::Customer.create will use the provided customer ID instead of
   overwriting it (#15).
+* Braintree::Customer.update will verify credit cards if `verify_card` is true.
 
 # 0.0.6
 * Flesh out the README

--- a/lib/fake_braintree/customer.rb
+++ b/lib/fake_braintree/customer.rb
@@ -21,8 +21,12 @@ module FakeBraintree
 
     def update
       if existing_customer_hash
-        hash = update_existing_customer!
-        gzipped_response(200, hash.to_xml(:root => 'customer'))
+        if invalid?
+          failure_response
+        else
+          hash = update_existing_customer!
+          gzipped_response(200, hash.to_xml(:root => 'customer'))
+        end
       else
         failure_response(404)
       end

--- a/spec/fake_braintree/customer_spec.rb
+++ b/spec/fake_braintree/customer_spec.rb
@@ -90,6 +90,26 @@ describe "Braintree::Customer.update" do
     Braintree::Customer.find(customer_id).first_name.should == "Jerry"
   end
 
+  it "returns a failure response when verification is requested and fails" do
+    customer_id = create_customer.customer.id
+    result = Braintree::Customer.update(customer_id, :credit_card => {
+      :number => '4000000000000000',
+      :options => { :verify_card => true }
+    })
+
+    result.should_not be_success
+  end
+
+  it "successfully updates the customer when verification is requested and succeeds" do
+    customer_id = create_customer.customer.id
+    result = Braintree::Customer.update(customer_id, :credit_card => {
+      :number => '4111111111111111',
+      :options => { :verify_card => true }
+    })
+
+    result.should be_success
+  end
+
   it "raises an error for a nonexistent customer" do
     lambda { Braintree::Customer.update("foo", {:first_name => "Bob"}) }.should raise_error(Braintree::NotFoundError)
   end


### PR DESCRIPTION
Something else I ran into when trying to get a failure scenario working. The patch is really simple, it just uses the same verification mechanisms from Customer.create.
