### PR TITLE
Use Thin as a dependency instead of Mongrel

### DIFF
--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n'
   s.add_dependency 'sinatra'
   s.add_dependency 'braintree', '~> 2.5'
-  s.add_dependency 'mongrel', '~> 1.2.0.pre'
+  s.add_dependency 'thin'
 
   s.add_development_dependency 'rspec', '~> 2.6.0'
   s.add_development_dependency 'bourne', '~> 1.0'

--- a/lib/fake_braintree/server.rb
+++ b/lib/fake_braintree/server.rb
@@ -1,10 +1,10 @@
 require 'capybara'
 require 'capybara/server'
-require 'rack/handler/mongrel'
+require 'rack/handler/thin'
 
 class FakeBraintree::Server
   def boot
-    with_mongrel_runner do
+    with_thin_runner do
       server = Capybara::Server.new(FakeBraintree::SinatraApp)
       server.boot
       ENV['GATEWAY_PORT'] = server.port.to_s
@@ -13,10 +13,10 @@ class FakeBraintree::Server
 
   private
 
-  def with_mongrel_runner
+  def with_thin_runner
     default_server_process = Capybara.server
     Capybara.server do |app, port|
-      Rack::Handler::Mongrel.run(app, :Port => port)
+      Rack::Handler::Thin.run(app, :Port => port)
     end
     yield
   ensure


### PR DESCRIPTION
I had a similar issue to the gentleman in issue thoughtbot/fake_braintree#13 - Mongrel's dependency graph requires old versions of the daemons gem.

I've moved to requiring the standard production-ready thin install - which should also work better for the majority of applications deployed on heroku. Specs are all green.
