### PR TITLE
Allow creation of a credit card record directly

### DIFF
--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -16,6 +16,10 @@ module FakeBraintree
       end
     end
 
+    def to_xml
+      @hash.to_xml(:root => 'credit_card')
+    end
+
     private
 
     def update_existing_credit_card

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -83,6 +83,20 @@ module FakeBraintree
       gzipped_response(200, credit_card.to_xml(:root => "credit_card"))
     end
 
+    post "/merchants/:merchant_id/payment_methods" do
+      opts = {
+        :token => md5("#{Time.now}#{rand}"),
+        :merchant_id => params[:merchant_id]
+      }
+      data = hash_from_request_body_with_key(request, 'credit_card')
+      if data[:token]
+        opts[:token] = data[:token]
+      end
+      credit_card = CreditCard.new(data, opts)
+      FakeBraintree.registry.credit_cards[opts[:token]] = credit_card
+      gzipped_response(200, credit_card.to_xml)
+    end
+
     # Braintree::CreditCard.update
     put "/merchants/:merchant_id/payment_methods/:credit_card_token" do
       credit_card = FakeBraintree.registry.credit_cards[params[:credit_card_token]]

--- a/spec/fake_braintree/credit_card_spec.rb
+++ b/spec/fake_braintree/credit_card_spec.rb
@@ -14,6 +14,19 @@ describe "Braintree::CreditCard.find" do
   let(:token) { braintree_credit_card_token(TEST_CC_NUMBER, [month, year].join('/')) }
 end
 
+describe "Braintree::CreditCard.create" do
+  let(:month) { '04' }
+  let(:year)  { '2016' }
+  let(:token) { braintree_credit_card_token(TEST_CC_NUMBER, [month, year].join('/')) }
+  it "successfully creates card with valid data" do
+    result = Braintree::CreditCard.create :token => token,
+      :number => TEST_CC_NUMBER
+    result.should be_success
+
+    Braintree::CreditCard.find(token).should be
+  end
+end
+
 describe "Braintree::CreditCard.sale" do
   it "successfully creates a sale" do
     result = Braintree::CreditCard.sale(cc_token, :amount => 10.00)


### PR DESCRIPTION
Allow support for Braintree::CreditCard.create action - for users storing a credit card in Braintree.
