### PR TITLE
Move create logic from sinatra into credit card.

### DIFF
--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -7,6 +7,11 @@ module FakeBraintree
       set_expiration_month_and_year
     end
 
+    def create
+      create_credit_card
+      response_for_created_card
+    end
+
     def update
       if credit_card_exists_in_registry?
         update_existing_credit_card
@@ -22,8 +27,16 @@ module FakeBraintree
 
     private
 
+    def create_credit_card
+      FakeBraintree.registry.credit_cards[@hash[:token]] = @hash
+    end
+
     def update_existing_credit_card
       @hash = credit_card_from_registry.merge!(@hash)
+    end
+
+    def response_for_created_card
+      gzipped_response(200, @hash.to_xml(:root => 'credit_card'))
     end
 
     def response_for_updated_card

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -83,18 +83,15 @@ module FakeBraintree
       gzipped_response(200, credit_card.to_xml(:root => "credit_card"))
     end
 
+    # Braintree::CreditCard.create
     post "/merchants/:merchant_id/payment_methods" do
       opts = {
         :token => md5("#{Time.now}#{rand}"),
         :merchant_id => params[:merchant_id]
       }
       data = hash_from_request_body_with_key(request, 'credit_card')
-      if data[:token]
-        opts[:token] = data[:token]
-      end
-      credit_card = CreditCard.new(data, opts)
-      FakeBraintree.registry.credit_cards[opts[:token]] = credit_card
-      gzipped_response(200, credit_card.to_xml)
+      opts[:token] = data[:token] if data[:token]
+      CreditCard.new(data, opts).create
     end
 
     # Braintree::CreditCard.update


### PR DESCRIPTION
This change follows the same pattern as the other classes and provides the groundwork for credit card transparent redirects.

https://www.braintreepayments.com/docs/ruby/credit_cards/create_tr
