### PR TITLE
Ensures there is a default credit card for the customer

### DIFF
--- a/lib/fake_braintree/customer.rb
+++ b/lib/fake_braintree/customer.rb
@@ -103,7 +103,7 @@ module FakeBraintree
 
     def set_default_credit_card(credit_card_hash)
       if credit_card_hash
-        CreditCard.new(credit_card_hash, customer_id: @customer_hash['id'], make_default: true).update
+        CreditCard.new(credit_card_hash, :customer_id => @customer_hash['id'], :make_default => true).update
       end
     end
 

--- a/spec/fake_braintree/customer_spec.rb
+++ b/spec/fake_braintree/customer_spec.rb
@@ -46,7 +46,7 @@ describe 'Braintree::Customer.create' do
     )
 
     credit_cards = Braintree::Customer.find(result.customer.id).credit_cards
-    credit_cards.first.default?.should be_true
+    credit_cards.first.should be_default
   end
 
   it 'can handle an empty credit card hash' do


### PR DESCRIPTION
I believe this is the behavior when using Braintree. When you create a user with a credit card using `TransparentRedirect` that credit card gets set as the default.

Also populates the credit card's `bin` property for usage in the `masked_number` method
