### PR TITLE
Allow transactions to forcibly be failed per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ Full example:
     #   "subscription_id" => "foobar"
     # }
 
+### Forcibly Failing a Transaction
+
+Transactions generally succeed, but if you need to simulate one failing for some reason, 
+use `FakeBraintree.fail_next_transaction_with(message)` to force the next transaction
+that would otherwise succeed to fail, with the given message.
+
+Example:
+
+    FakeBraintree.fail_next_transaction_with('Cannot refund more than was charged')
+
+    response = Braintree::Transaction.refund('ghfytr',1000.00)
+    response.success? # => false
+    response.message  # => 'Cannot refund more than was charged'
+
 Credits
 -------
 

--- a/lib/fake_braintree.rb
+++ b/lib/fake_braintree.rb
@@ -15,7 +15,7 @@ require 'fake_braintree/valid_credit_cards'
 require 'fake_braintree/version'
 
 module FakeBraintree
-  mattr_accessor :registry, :verify_all_cards, :decline_all_cards
+  mattr_accessor :registry, :verify_all_cards, :decline_all_cards, :fail_next_transaction_message
 
   def self.activate!
     initialize_registry
@@ -62,17 +62,27 @@ module FakeBraintree
     }
   end
 
-  def self.create_failure
+  def self.create_failure(message = 'Do Not Honor')
     {
-      'message' => 'Do Not Honor',
+      'message' => message,
       'verification' => {
         'status' => 'processor_declined',
-        'processor_response_text' => 'Do Not Honor',
+        'processor_response_text' => message,
         'processor_response_code' => '2000'
       },
       'errors' => { 'errors' => [] },
       'params' => {}
     }
+  end
+
+  # The next transaction attempted that would otherwise succeed should fail
+  # with the given message
+  def self.fail_next_transaction_with(message)
+    self.fail_next_transaction_message = message
+  end
+
+  def self.fail_next_transaction?
+    !self.fail_next_transaction_message.nil?
   end
 
   def self.decline_all_cards!

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -117,6 +117,10 @@ module FakeBraintree
     post '/merchants/:merchant_id/transactions' do
       if FakeBraintree.decline_all_cards?
         gzipped_response(422, FakeBraintree.create_failure.to_xml(:root => 'api_error_response'))
+      elsif FakeBraintree.fail_next_transaction?
+        error_message = FakeBraintree.fail_next_transaction_message
+        FakeBraintree.fail_next_transaction_with(nil)
+        gzipped_response(422, FakeBraintree.create_failure(error_message).to_xml(:root => 'api_error_response'))
       else
         transaction = hash_from_request_body_with_key('transaction')
         transaction_id = md5("#{params[:merchant_id]}#{Time.now.to_f}")
@@ -147,18 +151,34 @@ module FakeBraintree
       transaction_id       = md5('#{params[:merchant_id]}#{Time.now.to_f}')
       transaction_response = {'id' => transaction_id, 'amount' => transaction['amount'], 'type' => 'credit'}
       FakeBraintree.registry.transactions[transaction_id] = transaction_response
-      gzipped_response(200, transaction_response.to_xml(:root => 'transaction'))
+      FakeBraintree.registry.failures["foo"] = {
+        "message" => "No can do",
+        "code" => 91234,
+      }
+      if FakeBraintree.fail_next_transaction?
+        error_message = FakeBraintree.fail_next_transaction_message
+        FakeBraintree.fail_next_transaction_with(nil)
+        gzipped_response(422, FakeBraintree.create_failure(error_message).to_xml(:root => 'api_error_response'))
+      else
+        gzipped_response(200, transaction_response.to_xml(:root => 'transaction'))
+      end
     end
 
     # Braintree::Transaction.void
     put '/merchants/:merchant_id/transactions/:transaction_id/void' do
-      transaction = FakeBraintree.registry.transactions[params[:transaction_id]]
-      transaction_response = {'id' => transaction['id'],
-                              'type' => transaction['sale'],
-                              'amount' => transaction['amount'],
-                              'status' => Braintree::Transaction::Status::Voided}
-      FakeBraintree.registry.transactions[transaction['id']] = transaction_response
-      gzipped_response(200, transaction_response.to_xml(:root => 'transaction'))
+      if FakeBraintree.fail_next_transaction?
+        error_message = FakeBraintree.fail_next_transaction_message
+        FakeBraintree.fail_next_transaction_with(nil)
+        gzipped_response(422, FakeBraintree.create_failure(error_message).to_xml(:root => 'api_error_response'))
+      else
+        transaction = FakeBraintree.registry.transactions[params[:transaction_id]]
+        transaction_response = {'id' => transaction['id'],
+                                'type' => transaction['sale'],
+                                'amount' => transaction['amount'],
+                                'status' => Braintree::Transaction::Status::Voided}
+        FakeBraintree.registry.transactions[transaction['id']] = transaction_response
+        gzipped_response(200, transaction_response.to_xml(:root => 'transaction'))
+      end
     end
 
     # Braintree::TransparentRedirect.url

--- a/spec/fake_braintree_spec.rb
+++ b/spec/fake_braintree_spec.rb
@@ -88,6 +88,23 @@ describe FakeBraintree, '.failure_response' do
   end
 end
 
+describe FakeBraintree, '.create_failure' do
+  it 'generates a reasonable response with no arguments' do
+    failure = FakeBraintree.create_failure
+
+    failure['message'].should == 'Do Not Honor'
+    failure['verification']['processor_response_text'].should == 'Do Not Honor'
+  end
+
+  it 'allows a customized error message' do
+    message = 'You have refunded too much'
+    failure = FakeBraintree.create_failure(message)
+
+    failure['message'].should == message
+    failure['verification']['processor_response_text'].should == message
+  end
+end
+
 describe FakeBraintree, '.generate_transaction' do
   it 'allows setting the subscription id' do
     transaction = FakeBraintree.generate_transaction(:subscription_id => 'foobar')
@@ -139,5 +156,26 @@ describe FakeBraintree, '.generate_transaction' do
       transaction = FakeBraintree.generate_transaction(:status => status)
       transaction['status_history'].first['status'].should == status
     end
+  end
+end
+
+describe FakeBraintree, '.fail_next_transaction_with' do
+  context 'a non-nil message' do
+    let(:message) { 'some_message' }
+
+    it 'sets fail_next_transaction_message' do
+      FakeBraintree.fail_next_transaction_with(message)
+      FakeBraintree.fail_next_transaction_message.should == message
+    end
+
+    it 'indicates the next transaction should fail' do
+      FakeBraintree.fail_next_transaction_with(message)
+      FakeBraintree.fail_next_transaction?.should == true
+    end
+  end
+
+  it "indicates the next transaction shouldn't fail" do
+      FakeBraintree.fail_next_transaction_with(nil)
+      FakeBraintree.fail_next_transaction?.should == false
   end
 end


### PR DESCRIPTION
Mostly needed because refunds cannot easily be tested against the
sandbox, but I still need to check what happens on failure.

Since it was odd to just add to refund, added to sale and void as well.
Also test coverage for `create_failure`, since I needed to allow
customizing the message.

Note: I'm not 100% sure what structure comes back on these failures, so
this might not be totally sufficient for everyone - likely just missing some things that would come back.  Since the feature didn't previously exist, I'm counting it this not breaking existing tests.
