### PR TITLE
Add support for creating a credit card with an existing billing address.

### DIFF
--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -4,6 +4,7 @@ module FakeBraintree
 
     def initialize(credit_card_hash_from_params, options)
       set_up_credit_card(credit_card_hash_from_params, options)
+      set_billing_address
       set_expiration_month_and_year
     end
 
@@ -102,6 +103,12 @@ module FakeBraintree
         'customer_id' => options[:customer_id],
         'default' => options[:make_default]
       }.merge(credit_card_hash_from_params)
+    end
+
+    def set_billing_address
+      if @hash["billing_address_id"]
+        @hash["billing_address"] = FakeBraintree.registry.addresses[@hash['billing_address_id']]
+      end
     end
 
     def set_expiration_month_and_year

--- a/spec/fake_braintree/credit_card_spec.rb
+++ b/spec/fake_braintree/credit_card_spec.rb
@@ -72,6 +72,7 @@ describe 'Braintree::CreditCard.create' do
       result.should be_success
       Braintree::Customer.find(@customer.id).credit_cards.last.token.should == 'token'
       Braintree::Customer.find(@customer.id).credit_cards.last.default?.should be_true
+      Braintree::Customer.find(@customer.id).credit_cards.last.billing_address.postal_code.should == "94110"
     end
 
     it 'only allows one credit card to be default' do


### PR DESCRIPTION
https://www.braintreepayments.com/docs/ruby/credit_cards/create

[#44776095]
