### PR TITLE
Add type to transactions.

### DIFF
--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -125,7 +125,7 @@ module FakeBraintree
         if options.fetch("submit_for_settlement", false) == true
           status = "submitted_for_settlement"
         end
-        transaction_response = {'id' => transaction_id, 'amount' => transaction['amount'], 'status' => status}
+        transaction_response = {'id' => transaction_id, 'amount' => transaction['amount'], 'status' => status, 'type' => 'sale'}
         FakeBraintree.registry.transactions[transaction_id] = transaction_response
         gzipped_response(200, transaction_response.to_xml(:root => 'transaction'))
       end

--- a/spec/fake_braintree/transaction_spec.rb
+++ b/spec/fake_braintree/transaction_spec.rb
@@ -8,6 +8,7 @@ describe FakeBraintree::SinatraApp do
         :amount => 10.00
       )
       result.should be_success
+      result.transaction.type.should == 'sale'
     end
 
     context 'when all cards are declined' do


### PR DESCRIPTION
Default to 'sale' since Braintree disables the 'credit' type unless you email them per:

https://www.braintreepayments.com/docs/ruby/transactions/credit
