### PR TITLE
adding support for BT submit_for_settlement call

### DIFF
--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -157,6 +157,17 @@ module FakeBraintree
       gzipped_response(200, transaction_response.to_xml(root: 'transaction'))
     end
 
+
+    put '/merchants/:merchant_id/transactions/:transaction_id/submit_for_settlement' do
+      transaction = FakeBraintree.registry.transactions[params[:transaction_id]]
+      transaction_response = {'id' => transaction['id'],
+                              'type' => transaction['sale'],
+                              'amount' => transaction['amount'],
+                              'status' => Braintree::Transaction::Status::SubmittedForSettlement}
+      FakeBraintree.registry.transactions[transaction['id']] = transaction_response
+      gzipped_response(200, transaction_response.to_xml(root: 'transaction'))
+    end
+
     # Braintree::Transaction.void
     put '/merchants/:merchant_id/transactions/:transaction_id/void' do
       transaction = FakeBraintree.registry.transactions[params[:transaction_id]]

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -92,6 +92,19 @@ describe 'Braintree::Subscription.update' do
   end
 end
 
+describe 'Braintree::Subscription.retry_charge' do
+  it 'can submit for settlement' do
+    subscription_id = create_subscription.subscription.id
+
+    authorized_transaction = Braintree::Subscription.retry_charge(subscription_id, 42.0).transaction
+    result = Braintree::Transaction.submit_for_settlement(
+      authorized_transaction.id
+    )
+    result.should be_success
+  end
+end
+
+
 describe 'Braintree::Subscription.cancel' do
   it 'can cancel a subscription' do
     subscription_id = create_subscription.subscription.id


### PR DESCRIPTION
Adding support for submit_for_settlement call

BT docs: https://www.braintreepayments.com/docs/ruby/subscriptions/retry_charge
my blog post: http://michalolah.com/blog/testing/ruby/rails/stubbing-external-services
