### PR TITLE
Move all `require`s into fake_braintree.rb

### DIFF
--- a/lib/fake_braintree.rb
+++ b/lib/fake_braintree.rb
@@ -1,6 +1,9 @@
-require 'fileutils'
 require 'braintree'
-require 'active_support/core_ext/module/attribute_accessors'
+require 'capybara'
+require 'digest/md5'
+require 'fileutils'
+require 'active_support/core_ext'
+require 'sinatra/base'
 
 require 'fake_braintree/helpers'
 require 'fake_braintree/customer'

--- a/lib/fake_braintree/helpers.rb
+++ b/lib/fake_braintree/helpers.rb
@@ -1,7 +1,3 @@
-require 'digest/md5'
-require 'active_support'
-require 'active_support/core_ext'
-
 module FakeBraintree
   module Helpers
     def gzip(content)

--- a/lib/fake_braintree/server.rb
+++ b/lib/fake_braintree/server.rb
@@ -1,6 +1,3 @@
-require 'capybara'
-require 'capybara/server'
-
 class FakeBraintree::Server
   def boot
     server = Capybara::Server.new(FakeBraintree::SinatraApp)

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -1,5 +1,3 @@
-require 'sinatra/base'
-
 module FakeBraintree
   class SinatraApp < Sinatra::Base
     set :show_exceptions, false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'bundler'
 Bundler.require
 
-require 'rspec'
 require 'fake_braintree'
 require 'timecop'
 


### PR DESCRIPTION
Remove unnecessary requires, like requiring `capybara` and `capybara/server`.
