### PR TITLE
Save discount amount when adding to Subscription

### DIFF
--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -71,7 +71,7 @@ module FakeBraintree
 
     def added_discounts
       if @subscription_hash['discounts'].is_a?(Hash) && @subscription_hash['discounts']['add']
-        @subscription_hash['discounts']['add'].map { |discount| { 'id' => discount['inherited_from_id'] } }
+        @subscription_hash['discounts']['add'].map { |discount| { 'id' => discount['inherited_from_id'], 'amount' => discount['amount'] } }
       else
         []
       end

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -105,11 +105,13 @@ describe 'Braintree::Subscription.find' do
 
   it 'returns discounts added with the subscription' do
     discount_id = 'def456'
-    subscription_id = create_subscription(discounts: { add: [{ inherited_from_id: discount_id, amount: BigDecimal.new('15.00') }]}).subscription.id
+    amount = BigDecimal.new('15.00')
+    subscription_id = create_subscription(discounts: { add: [{ inherited_from_id: discount_id, amount: amount }]}).subscription.id
     subscription = Braintree::Subscription.find(subscription_id)
     discounts = subscription.discounts
     expect(discounts.size).to eq 1
     expect(discounts.first.id).to eq discount_id
+    expect(discounts.first.amount).to eq amount
   end
 
   it 'finds subscriptions created with custom id' do


### PR DESCRIPTION
When adding a discount to a Braintree subscription, the amount [can be set](https://developers.braintreepayments.com/ios+ruby/sdk/server/recurring-billing/create#overriding-plan-details) to anything (which we [are already doing](https://github.com/chrishunt/fake_braintree/blob/a5203386303e069a3e665b6687b00eced6b9bc2a/spec/fake_braintree/subscription_spec.rb#L108) in the tests). Unfortunately, we're not actually saving this amount on the discount. This PR fixes that. :smiley: 
