### PR TITLE
Avoid RSpec deprecation warnings due to `be_true/be_false`

### DIFF
--- a/spec/fake_braintree/registry_spec.rb
+++ b/spec/fake_braintree/registry_spec.rb
@@ -20,12 +20,12 @@ end
 
 describe FakeBraintree::Registry, '#failure?' do
   it 'returns false if the given CC number is not marked as a failure' do
-    expect(FakeBraintree::Registry.new.failure?('not-a-failure')).to be_false
+    expect(FakeBraintree::Registry.new.failure?('not-a-failure')).to be(false)
   end
 
   it 'returns true if the given CC number is marked as a failure' do
     registry = FakeBraintree::Registry.new
     registry.failures['abc123'] = 'whatever'
-    expect(registry.failure?('abc123')).to be_true
+    expect(registry.failure?('abc123')).to be(true)
   end
 end


### PR DESCRIPTION
Fixes these warnings:

```
`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics)
or `be false` (for exact `== false` equality) instead.

`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics)
or `be true` (for exact `== true` equality) instead.
```

Using rspec-expectations v2.99.2
