### PR TITLE
Fix crash on empty payment_method

### DIFF
--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -213,7 +213,8 @@ module FakeBraintree
         else
           payment_method_hash = hash_from_request_body_with_key('payment_method')
           nonce = payment_method_hash.delete('payment_method_nonce')
-          FakeBraintree.registry.payment_methods[nonce].merge(payment_method_hash)
+          h = FakeBraintree.registry.payment_methods[nonce] || {}
+          FakeBraintree.registry.payment_methods[nonce] = h.merge(payment_method_hash)
         end
       options = {merchant_id: params[:merchant_id]}
 

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -213,8 +213,8 @@ module FakeBraintree
         else
           payment_method_hash = hash_from_request_body_with_key('payment_method')
           nonce = payment_method_hash.delete('payment_method_nonce')
-          h = FakeBraintree.registry.payment_methods[nonce] || {}
-          FakeBraintree.registry.payment_methods[nonce] = h.merge(payment_method_hash)
+          h = FakeBraintree.registry.payment_methods
+          h[nonce] = (h[nonce] || {}).merge(payment_method_hash)
         end
       options = {merchant_id: params[:merchant_id]}
 


### PR DESCRIPTION
Not totally sure how we got to this state, but we got many crashes where FakeBraintree.registry.payment_methods[nonce] was nil and therefore couldn't merge.  This is the dumbest fix possible, but it works.