### PR TITLE
Bugfix: Ignore empty discount/addon arrays

### DIFF
--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -87,7 +87,7 @@ module FakeBraintree
     def discounts_or_add_ons(discount_or_add_on)
       return [] unless discount_or_add_on.is_a?(Hash)
 
-      if discount_or_add_on['add']
+      if Array(discount_or_add_on['add']).any?
         discount_or_add_on['add'].map do |hsh|
           {
             'id'       => hsh['inherited_from_id'],
@@ -95,7 +95,7 @@ module FakeBraintree
             'amount'   => hsh['amount']
           }
         end
-      elsif discount_or_add_on['update']
+      elsif Array(discount_or_add_on['update']).any?
         discount_or_add_on['update'].map do |hsh|
           {
             'id'       => hsh['existing_id'],

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -152,6 +152,17 @@ describe 'Braintree::Subscription.find' do
     expect(discounts.first.quantity).to eq 5
   end
 
+  it 'updates an existing discount if an empty :add array is given' do
+    discount_id = 'abc123'
+    subscription_id = create_subscription(discounts: { add: [{ inherited_from_id: discount_id, quantity: 2 }] }).subscription.id
+    update_subscription(subscription_id, discounts: { add: [], update: [{ existing_id: discount_id, quantity: 5 }] })
+    subscription = Braintree::Subscription.find(subscription_id)
+    discounts = subscription.discounts
+    expect(discounts.size).to eq 1
+    expect(discounts.first.id).to eq discount_id
+    expect(discounts.first.quantity).to eq 5
+  end
+
   it 'finds subscriptions created with custom id' do
     create_subscription(id: 'bob-smiths-subscription')
     expect(Braintree::Subscription.find('bob-smiths-subscription')).to be_a Braintree::Subscription


### PR DESCRIPTION
The Braintree API is just fine with accepting an empty array – so FakeBraintree
should be fine with this as well.

Example:

``` ruby
Braintree::Subscription.update(subscription_id, discounts: {
  add: [],
  update: [{ existing_id: some_id, amount: some_amount }]
})
```

This previously failed because FakeBraintree would stop at the `add` key since
it can be found and isn't nil. After this patch, FakeBraintree continues on the
empty array and correctly updates the discount.