### PR TITLE
Bugfix: Ensure creation time is set when records are created

### DIFF
--- a/lib/fake_braintree/address.rb
+++ b/lib/fake_braintree/address.rb
@@ -10,6 +10,7 @@ module FakeBraintree
 
     def create
       @address['id'] = generate_id
+      @address['created_at'] = Time.now
       FakeBraintree.registry.addresses[id] = @address
       customer['addresses'] << @address
       response_for_updated_address

--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -20,6 +20,7 @@ module FakeBraintree
         if token.nil?
           @credit_card['token'] = generate_token
         end
+        @credit_card['created_at'] = Time.now
         FakeBraintree.registry.credit_cards[token] = @credit_card
         if customer = FakeBraintree.registry.customers[@credit_card['customer_id']]
           customer['credit_cards'] << @credit_card

--- a/lib/fake_braintree/customer.rb
+++ b/lib/fake_braintree/customer.rb
@@ -28,6 +28,7 @@ module FakeBraintree
         create_customer_with(customer_hash)
         credit_cards.each { |card| add_credit_card_to_registry(card) }
         set_default_credit_card credit_cards.first
+        @customer_hash['created_at'] = Time.now
         response_for_created_customer(customer_hash)
       end
     end

--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -253,7 +253,7 @@ module FakeBraintree
     post '/merchants/:merchant_id/transactions/:transaction_id/refund' do
       transaction          = hash_from_request_body_with_key('transaction')
       transaction_id       = md5("#{params[:merchant_id]}#{Time.now.to_f}")
-      transaction_response = {'id' => transaction_id, 'amount' => transaction['amount'], 'type' => 'credit'}
+      transaction_response = {'id' => transaction_id, 'amount' => transaction['amount'], 'type' => 'credit', 'created_at' => Time.now}
       FakeBraintree.registry.transactions[transaction_id] = transaction_response
       gzipped_response(200, transaction_response.to_xml(root: 'transaction'))
     end

--- a/lib/fake_braintree/subscription.rb
+++ b/lib/fake_braintree/subscription.rb
@@ -15,6 +15,7 @@ module FakeBraintree
     end
 
     def create
+      @subscription_hash['created_at'] = Time.now
       create_subscription_with(subscription_hash)
       if credit_card = FakeBraintree.registry.credit_cards[payment_method_token]
         credit_card['subscriptions'] ||= []

--- a/lib/fake_braintree/transaction.rb
+++ b/lib/fake_braintree/transaction.rb
@@ -12,7 +12,8 @@ module FakeBraintree
         "id" => id,
         "amount" => data["amount"],
         "status" => status,
-        "type" => "sale"
+        "type" => "sale",
+        "created_at" => Time.now
       }
 
       FakeBraintree.registry.transactions[id] = response

--- a/spec/fake_braintree/address_spec.rb
+++ b/spec/fake_braintree/address_spec.rb
@@ -1,14 +1,21 @@
 require 'spec_helper'
 
 describe "Braintree::Address.create" do
-  it "successfully creates address with valid data" do
-    customer_response = create_customer
+  let(:customer) { create_customer.customer }
 
+  it "successfully creates address with valid data" do
     address_response = Braintree::Address.create(
-      customer_id: customer_response.customer.id,
+      customer_id: customer.id,
       postal_code: 30339
     )
 
     expect(address_response).to be_success
+  end
+
+  it "sets the creation time" do
+    address = Braintree::Address.create(customer_id: customer.id).address
+
+    creation_time = Time.parse(address.created_at)
+    expect(creation_time).to be_within(1).of(Time.now)
   end
 end

--- a/spec/fake_braintree/credit_card_spec.rb
+++ b/spec/fake_braintree/credit_card_spec.rb
@@ -77,6 +77,13 @@ describe 'Braintree::CreditCard.create' do
     end
   end
 
+  it "sets the creation time" do
+    credit_card = Braintree::CreditCard.create(build_credit_card_hash).credit_card
+
+    creation_time = Time.parse(credit_card.created_at)
+    expect(creation_time).to be_within(1).of(Time.now)
+  end
+
   def build_credit_card_hash
     {
       customer_id: @customer && @customer.id,

--- a/spec/fake_braintree/customer_spec.rb
+++ b/spec/fake_braintree/customer_spec.rb
@@ -114,6 +114,18 @@ describe 'Braintree::Customer.create' do
     expect(billing_address.street_address).to eq '1 E Main St'
     expect(billing_address.postal_code).to eq '60622'
   end
+
+  it "sets the creation time" do
+    customer = Braintree::Customer.create(
+      credit_card: {
+        number: TEST_CC_NUMBER,
+        expiration_date: '04/2016'
+      }
+    ).customer
+
+    creation_time = Time.parse(customer.created_at)
+    expect(creation_time).to be_within(1).of(Time.now)
+  end
 end
 
 describe 'Braintree::Customer.create', 'when passed verify_card: true' do

--- a/spec/fake_braintree/subscription_spec.rb
+++ b/spec/fake_braintree/subscription_spec.rb
@@ -88,6 +88,12 @@ describe 'Braintree::Subscription.create' do
     end
   end
 
+  it "sets the creation time" do
+    subscription = create_subscription.subscription
+
+    creation_time = Time.parse(subscription.created_at)
+    expect(creation_time).to be_within(1).of(Time.now)
+  end
 end
 
 describe 'Braintree::Subscription.find' do

--- a/spec/fake_braintree/transaction_spec.rb
+++ b/spec/fake_braintree/transaction_spec.rb
@@ -11,6 +11,16 @@ describe FakeBraintree::SinatraApp do
       expect(result.transaction.type).to eq 'sale'
     end
 
+    it "sets the creation time" do
+      transaction = Braintree::Transaction.sale(
+        payment_method_token: cc_token,
+        amount: 10.00
+      ).transaction
+
+      creation_time = Time.parse(transaction.created_at)
+      expect(creation_time).to be_within(1).of(Time.now)
+    end
+
     context 'when all cards are declined' do
       before { FakeBraintree.decline_all_cards! }
 
@@ -76,6 +86,13 @@ describe FakeBraintree::SinatraApp do
     it 'successfully refunds a transaction' do
       result = Braintree::Transaction.refund(create_id('foobar'), '1')
       expect(result).to be_success
+    end
+
+    it "sets the creation time" do
+      transaction = Braintree::Transaction.refund(create_id('foobar'), '1').transaction
+
+      creation_time = Time.parse(transaction.created_at)
+      expect(creation_time).to be_within(1).of(Time.now)
     end
   end
 end


### PR DESCRIPTION
According go the API docs, pretty much every record in the Braintree API has a `created_at` field – so we should have them as well.