### PR TITLE
Fixed broken spec

### DIFF
--- a/spec/fake_braintree/payment_method_spec.rb
+++ b/spec/fake_braintree/payment_method_spec.rb
@@ -40,7 +40,7 @@ describe 'Braintree::PaymentMethod.delete' do
 
     result = Braintree::PaymentMethod.delete(token)
 
-    expect(result).to eq true
+    expect(result).to be_success
 
     expect {
       Braintree::PaymentMethod.find(token)


### PR DESCRIPTION
Hey everybody!

I noticed there was a failing test in this repo (because I'd like to start doing some work on it!) 

In one of the tests Braintree::PaymentMethod.delete was expected to return a boolean but it returns success object instead (as per the Braintree docs: https://developers.braintreepayments.com/reference/request/payment-method/delete/ruby)

Thanks for taking a look and all the work on this library!
