### PR TITLE
Fix for Issue 122 - Resolve Sinatra dependency to '2.0.0.beta2' in Gemspec

### DIFF
--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -15,15 +15,15 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.4.1")
 
   s.add_dependency 'activesupport'
-  s.add_dependency 'braintree', '~> 2.32'
-  s.add_dependency 'capybara', '>= 2.2.0'
+  s.add_dependency 'braintree', '~> 2.61'
+  s.add_dependency 'capybara', '>= 2.3.0'
   s.add_dependency 'sinatra'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.2'
-  s.add_development_dependency 'timecop', '~> 0.6'
+  s.add_development_dependency 'timecop', '~> 0.8.1'
   s.add_development_dependency 'capybara-webkit'
 end

--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
-
   s.add_dependency 'activesupport'
   s.add_dependency 'braintree', '~> 2.32'
   s.add_dependency 'capybara', '>= 2.2.0'

--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 2.4.1")
 
 
-  s.add_dependency 'activesupport', '~> 5.0'
-  s.add_dependency 'braintree', '~> 2.61'
+  s.add_dependency 'activesupport'
+  s.add_dependency 'braintree', '~> 2.32'
   s.add_dependency 'capybara', '>= 2.2.0'
   s.add_dependency 'sinatra', '~> 2.0.0.beta2'
 
-  s.add_development_dependency 'rake', '~> 0'
-  s.add_development_dependency 'rspec', '~> 3.5'
-  s.add_development_dependency 'timecop', '~> 0.8.1'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'timecop', '~> 0.6'
   s.add_development_dependency 'capybara-webkit'
 end

--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -17,13 +17,14 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = Gem::Requirement.new(">= 2.4.1")
 
-  s.add_dependency 'activesupport'
-  s.add_dependency 'braintree', '~> 2.61'
-  s.add_dependency 'capybara', '>= 2.3.0'
-  s.add_dependency 'sinatra'
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_dependency 'activesupport', '~> 5.0'
+  s.add_dependency 'braintree', '~> 2.61'
+  s.add_dependency 'capybara', '>= 2.2.0'
+  s.add_dependency 'sinatra', '~> 2.0.0.beta2'
+
+  s.add_development_dependency 'rake', '~> 0'
+  s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'timecop', '~> 0.8.1'
   s.add_development_dependency 'capybara-webkit'
 end

--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.required_ruby_version = Gem::Requirement.new(">= 2.4.1")
+  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
 
   s.add_dependency 'activesupport'


### PR DESCRIPTION
Issue referenced here: [https://github.com/highfidelity/fake_braintree/issues/121](https://github.com/highfidelity/fake_braintree/issues/121)

Prior to 2.0.0.beta2, Sinatra supported an incorrect Rack requirement for the showexceptions file:
[https://github.com/sinatra/sinatra/issues/1055](https://github.com/sinatra/sinatra/issues/1055)

When attempting to load fake_braintree into the test environment, I'd receive this error highlighted in the issue above:

`local/bundle/gems/sinatra-1.0/lib/sinatra/showexceptions.rb:1:in 'require': cannot load such file -- rack/showexceptions (LoadError)`

By updating Sinatra in the gemspec, the ability to load the gem via Rack is restored.

This PR does not address the 3 failing spec tests.