### PR TITLE
support credit card payment_method_nonce lookup

### DIFF
--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
   s.add_dependency 'activesupport'
-  s.add_dependency 'braintree', '~> 2.32'
+  s.add_dependency 'braintree', '~> 4.26'
   s.add_dependency 'capybara', '>= 2.2.0'
   s.add_dependency 'sinatra'
 

--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -1,8 +1,9 @@
 require 'fake_braintree/helpers'
 require 'fake_braintree/valid_credit_cards'
+require 'fake_braintree/payment_method'
 
 module FakeBraintree
-  class CreditCard
+  class CreditCard < PaymentMethod
     include Helpers
 
     def initialize(credit_card_hash_from_params, options)

--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -104,7 +104,7 @@ module FakeBraintree
     end
 
     def response_for_invalid_card
-      body = FakeBraintree.failure_response.merge(
+      body = FakeBraintree.failure_response(number).merge(
         'params' => {credit_card: @credit_card}
       ).to_xml(root: 'api_error_response')
 

--- a/lib/fake_braintree/credit_card.rb
+++ b/lib/fake_braintree/credit_card.rb
@@ -44,6 +44,10 @@ module FakeBraintree
 
     def delete
       if credit_card_exists_in_registry?
+        if customer = FakeBraintree.registry.customers[credit_card_from_registry["customer_id"]]
+          customer["credit_cards"].reject! { |card| card["token"] === token }
+        end
+
         delete_credit_card
         deletion_response
       else

--- a/lib/fake_braintree/helpers.rb
+++ b/lib/fake_braintree/helpers.rb
@@ -1,5 +1,6 @@
 require 'digest/md5'
 require 'active_support/gzip'
+require 'securerandom'
 
 module FakeBraintree
   module Helpers
@@ -16,7 +17,7 @@ module FakeBraintree
     end
 
     def create_id(merchant_id)
-      md5("#{merchant_id}#{Time.now.to_f}")
+      SecureRandom.hex
     end
   end
 end

--- a/spec/fake_braintree/credit_card_spec.rb
+++ b/spec/fake_braintree/credit_card_spec.rb
@@ -65,6 +65,16 @@ describe 'Braintree::CreditCard.create' do
       expect(Braintree::Customer.find(@customer.id).credit_cards.last.billing_address.postal_code).to eq "94110"
     end
 
+    it 'successfully creates a credit card from a payment_method_nonce' do
+      nonce = FakeBraintree::CreditCard.tokenize_card(build_credit_card_hash)
+      result = Braintree::CreditCard.create(payment_method_nonce: nonce, customer_id: @customer.id)
+
+      expect(result).to be_success
+      expect(Braintree::Customer.find(@customer.id).credit_cards.last.token).to eq 'token'
+      expect(Braintree::Customer.find(@customer.id).credit_cards.last).to be_default
+      expect(Braintree::Customer.find(@customer.id).credit_cards.last.billing_address.postal_code).to eq "94110"
+    end
+
     it 'only allows one credit card to be default' do
       result = Braintree::CreditCard.create(build_credit_card_hash)
       expect(result).to be_success


### PR DESCRIPTION
Supports the ability to pass in `payment_method_nonce` into `Braintree::CreditCard.create`. See the [Braintree documentation](https://developers.braintreepayments.com/reference/request/credit-card/create/ruby#payment_method_nonce).
```
Finished in 3.76 seconds (files took 1.11 seconds to load)
144 examples, 0 failures
```