### PR TITLE
Update fake_braintree.gemspec

### DIFF
--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport'
   s.add_dependency 'braintree', '~> 2.32'
   s.add_dependency 'capybara', '>= 2.2.0'
+  s.add_dependency 'tilt', '~> 1.4.1'
   s.add_dependency 'sinatra'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Fixes the loading error: uninitialized constant Tilt::CompileSite.

This error seems to be in between Sinatra and Tilt version 2.x. Downgrading to 1.4.x solved the issue.